### PR TITLE
Migrate contact form from Supabase to Netlify Forms

### DIFF
--- a/content/pages/_partials/footer.php
+++ b/content/pages/_partials/footer.php
@@ -54,6 +54,17 @@
         </div>
     </footer>
 
+    <!-- Hidden form for Netlify bot detection (not shown to users) -->
+    <form name="contact" method="POST" data-netlify="true" netlify-honeypot="bot-field" hidden>
+        <input type="text" name="bot-field">
+        <input type="text" name="name">
+        <input type="email" name="email">
+        <input type="text" name="website">
+        <textarea name="message"></textarea>
+        <input type="text" name="currency">
+        <input type="text" name="timezone">
+    </form>
+
     <!-- Contact Modal -->
     <div x-cloak x-show="showContact" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="fixed inset-0 z-50 flex items-center justify-center">
         <!-- Drop layer -->
@@ -64,6 +75,7 @@
             <h2 class="text-2xl md:text-3xl font-semibold mt-4 mb-4 leading-tight tracking-tight bg-gradient-to-b from-stone-800 to-stone-500 bg-clip-text text-transparent">Get your website back on track!</h2>
             <p class="mb-6 text-stone-700 font-light">Tell us what's not working – the more details you share now, the faster we can help you with a clear solution.</p>
             <form @submit.prevent="submit()" class="space-y-4">
+                <input type="hidden" name="form-name" value="contact">
                 <input type="text" x-model="bot" name="bot-field" class="hidden" tabindex="-1" autocomplete="off">
                 <template x-if="success">
                     <div class="p-3 rounded bg-green-100 text-green-800 text-center">Thank you! Your message has been sent.</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "phpfixer",
       "version": "1.0.0",
       "dependencies": {
-        "@alpinejs/collapse": "^3.15.11",
-        "@supabase/supabase-js": "^2.103.3"
+        "@alpinejs/collapse": "^3.15.11"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
@@ -866,92 +865,6 @@
         "win32"
       ]
     },
-    "node_modules/@supabase/auth-js": {
-      "version": "2.103.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
-      "integrity": "sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.103.3",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.3.tgz",
-      "integrity": "sha512-A2ZHi95GIRRlN9LGOSa/zGEIPg9taR1giDI9Gkfkgrcz0YmKV8ShiAplIrKsHQFdkzKxtsO3maJF0efL+i31mg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/phoenix": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
-      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
-      "license": "MIT"
-    },
-    "node_modules/@supabase/postgrest-js": {
-      "version": "2.103.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.3.tgz",
-      "integrity": "sha512-S0k/9FJVXDeejNfQLCJwRlm4IH8Wet/HEEdBTBpX6/G2o1eU/6CjQop/hJPZIwlQkI6D/zbHH8KymuCsBgy6jA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/realtime-js": {
-      "version": "2.103.3",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.3.tgz",
-      "integrity": "sha512-fUvKtSXMUk1BkApVwAurWtHF4Vzbb0UB9aC/fQXrRBek7Ta3Kaora+wHf/fGwFNQs7uRz+mvjIVpzLfpR32VXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/phoenix": "^0.4.0",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/storage-js": {
-      "version": "2.103.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.3.tgz",
-      "integrity": "sha512-5bAIEubrw5keHcdKR2RTois0O1M2Ilx4UYuzOzc07G6mLGCPS/8t1nbC6Vq451pnxR3sK+rmtFHWb9CY/OPjAw==",
-      "license": "MIT",
-      "dependencies": {
-        "iceberg-js": "^0.8.1",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/supabase-js": {
-      "version": "2.103.3",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.3.tgz",
-      "integrity": "sha512-DuPiAz5pIJsTAQCt7B6bDZrnLzlq9+/5bta/GWTsgpLn6AkuZQcmYsQHYplv4skQ8U2raKY5HASQOu4KtYq9Qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-js": "2.103.3",
-        "@supabase/functions-js": "2.103.3",
-        "@supabase/postgrest-js": "2.103.3",
-        "@supabase/realtime-js": "2.103.3",
-        "@supabase/storage-js": "2.103.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1235,18 +1148,12 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -1381,15 +1288,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/iceberg-js": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
-      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -1837,13 +1735,18 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite": {
       "version": "6.4.2",
@@ -1916,27 +1819,6 @@
           "optional": true
         },
         "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "vite": "^6.0.0"
   },
   "dependencies": {
-    "@alpinejs/collapse": "^3.15.11",
-    "@supabase/supabase-js": "^2.103.3"
+    "@alpinejs/collapse": "^3.15.11"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,14 +4,6 @@ import './style.css';
 // Import Alpine.js
 import Alpine from 'alpinejs';
 
-// Import Supabase
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-    import.meta.env.VITE_SUPABASE_URL,
-    import.meta.env.VITE_SUPABASE_ANON_KEY
-);
-
 // Contact form component
 Alpine.data('contactForm', () => ({
     name: '',
@@ -31,26 +23,34 @@ Alpine.data('contactForm', () => ({
 
         const currency = Alpine.store('currency');
 
-        const { error } = await supabase
-            .from('enquiries')
-            .insert({
+        try {
+            const body = new URLSearchParams({
+                'form-name': 'contact',
+                'bot-field': this.bot,
                 name: this.name,
                 email: this.email,
-                website: this.website || null,
+                website: this.website || '',
                 message: this.message,
                 currency: currency.symbol + currency.bugCheck + ' / ' + currency.symbol + currency.retainer,
                 timezone: currency.timezone,
             });
 
-        if (error) {
-            this.error = true;
-        } else {
+            const response = await fetch('/', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString(),
+            });
+
+            if (!response.ok) throw new Error('Network response was not ok');
+
             this.success = true;
             fathom.trackEvent('contact form submitted');
             this.name = '';
             this.email = '';
             this.website = '';
             this.message = '';
+        } catch {
+            this.error = true;
         }
 
         this.loading = false;


### PR DESCRIPTION
## Summary

- Replaces Supabase insert with a `fetch()` POST to Netlify Forms (URL-encoded body)
- Adds a hidden static form in `footer.php` so Netlify's build-time bot can detect the form
- Removes `@supabase/supabase-js` dependency — no more env vars needed

## Why

Supabase was hibernating due to inactivity, silently dropping all contact form submissions.

## How Netlify Forms works here

Since the form lives inside an Alpine.js modal (JS-rendered), Netlify's spider can't detect it at deploy time. The fix is a hidden `<form data-netlify="true">` with all the same field names — Netlify registers it at build time, then the Alpine `fetch()` POST matches it at runtime.

Submission flow:
1. User submits → Alpine calls `fetch('/', { method: 'POST', body: URLSearchParams })`
2. Body includes `form-name=contact` so Netlify routes it correctly
3. Submissions appear in the Netlify Forms dashboard (Forms → contact)

## Test plan

- [ ] Deploy preview builds without errors
- [ ] Open contact modal, submit a test message
- [ ] Confirm submission appears in Netlify dashboard under Forms → contact
- [ ] Confirm error state shows on network failure
- [ ] Confirm honeypot still blocks bot submissions (bot-field filled → silent drop)

https://claude.ai/code/session_01CKj57SH4FVd7GLoc4K1YuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKj57SH4FVd7GLoc4K1YuM)_